### PR TITLE
Add configurable join message delay

### DIFF
--- a/BungeeJoinMessages/src/main/java/java/tv/tirco/bungeejoin/Listener/PlayerListener.java
+++ b/BungeeJoinMessages/src/main/java/java/tv/tirco/bungeejoin/Listener/PlayerListener.java
@@ -161,7 +161,7 @@ public class PlayerListener implements Listener{
 
 
 		 }
-	 }, 3, TimeUnit.SECONDS);
+	 }, Main.getInstance().getConfig().getInt("Messages.Misc.JoinMessageDelaySeconds", 3), TimeUnit.SECONDS);
 
 //        for (ProxiedPlayer player : ProxyServer.getInstance().getPlayers()) {
 //        	

--- a/BungeeJoinMessages/src/main/resources/config.yml
+++ b/BungeeJoinMessages/src/main/resources/config.yml
@@ -51,6 +51,8 @@ Messages:
         ConsoleSilentMoveEvent: "&1Move Event was silenced. <player> <from> -> <to>"
         ConsoleSilentJoinEvent: "&6Join Event was silenced. <player> joined the network."
         ConsoleSilentQuitEvent: "&cQuit Event was silenced. <player> left the network."
+        ##Don't lower this delay too much or you may get false join messages from banned/failed logins
+        JoinMessageDelaySeconds: 3
 Settings:
     ##Should players with the bungeejoinmessages.silent permission be silenced by default?
     ##It will be set to this for all players after a reboot. They can toggle it for themselves with the /fakemessage toggle command


### PR DESCRIPTION
This is just a simple change to allow the join message delay to be configurable.

By default, everything will remain the same for existing users, it should add the default value of `3` into the `config.yml`. I'm currently running this on my own network and it's working great.

I understand the concerns and hesitations discussed in #8 but I think there are scenarios (like ours) where we would rather have a more timely join message than a possible false one from a ban. We use proxy based bans (not relying on server bans) and players are refused almost immediately, even 1s is more than enough time to validate the player is connected.

